### PR TITLE
Use pypandoc to convert long_description to RST

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
@@ -6,8 +6,14 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
-    long_description = f.read()
+try:
+    import pypandoc
+    long_description = pypandoc.convert('README.md', 'rst')
+except ImportError:
+    with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+        long_description = f.read()
+
+
 
 setup(
     name='quantorxs',


### PR DESCRIPTION
This code (borrowed from pypa)[https://packaging.python.org] uses pypandoc to automatically convert the markdown README to RST. For it to work pypandoc must be installed. 